### PR TITLE
Update to rustup and update ethkey and rlp dependency

### DIFF
--- a/rust/signer/Cargo.lock
+++ b/rust/signer/Cargo.lock
@@ -3,10 +3,10 @@ name = "signer"
 version = "0.1.0"
 dependencies = [
  "blockies 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethkey 0.2.0 (git+https://github.com/ethcore/parity)",
+ "ethkey 0.2.0 (git+https://github.com/paritytech/parity)",
  "jni 0.3.1 (git+https://github.com/prevoty/jni-rs)",
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "rlp 0.1.0 (git+https://github.com/ethcore/parity)",
+ "rlp 0.1.0 (git+https://github.com/paritytech/parity)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "elastic-array"
 version = "0.6.0"
-source = "git+https://github.com/ethcore/elastic-array#346f1ba5982576dab9d0b8fa178b50e1db0a21cd"
+source = "git+https://github.com/paritytech/elastic-array#346f1ba5982576dab9d0b8fa178b50e1db0a21cd"
 dependencies = [
  "heapsize 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -106,7 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "eth-secp256k1"
 version = "0.5.6"
-source = "git+https://github.com/ethcore/rust-secp256k1#b6b67055edc929057e97d64f036c78ad91f58a7f"
+source = "git+https://github.com/paritytech/rust-secp256k1#b6b67055edc929057e97d64f036c78ad91f58a7f"
 dependencies = [
  "arrayvec 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 name = "ethcore-bigint"
 version = "0.1.2"
-source = "git+https://github.com/ethcore/parity#9efab789aa875ad3b6930403135ea9bdf1c3468b"
+source = "git+https://github.com/paritytech/parity#93ee2a9b64c5ddc9655b1927836378ac915a7813"
 dependencies = [
  "bigint 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -130,11 +130,11 @@ dependencies = [
 [[package]]
 name = "ethkey"
 version = "0.2.0"
-source = "git+https://github.com/ethcore/parity#9efab789aa875ad3b6930403135ea9bdf1c3468b"
+source = "git+https://github.com/paritytech/parity#93ee2a9b64c5ddc9655b1927836378ac915a7813"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth-secp256k1 0.5.6 (git+https://github.com/ethcore/rust-secp256k1)",
- "ethcore-bigint 0.1.2 (git+https://github.com/ethcore/parity)",
+ "eth-secp256k1 0.5.6 (git+https://github.com/paritytech/rust-secp256k1)",
+ "ethcore-bigint 0.1.2 (git+https://github.com/paritytech/parity)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -296,11 +296,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rlp"
 version = "0.1.0"
-source = "git+https://github.com/ethcore/parity#9efab789aa875ad3b6930403135ea9bdf1c3468b"
+source = "git+https://github.com/paritytech/parity#93ee2a9b64c5ddc9655b1927836378ac915a7813"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic-array 0.6.0 (git+https://github.com/ethcore/elastic-array)",
- "ethcore-bigint 0.1.2 (git+https://github.com/ethcore/parity)",
+ "elastic-array 0.6.0 (git+https://github.com/paritytech/elastic-array)",
+ "ethcore-bigint 0.1.2 (git+https://github.com/paritytech/parity)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -378,12 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 "checksum combine 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89749770bffc77cb34db11b60d5d4b197388b46bc7774ac8acbde33c26ad6c08"
 "checksum deflate 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebb02aaf4b775afc96684b8402510a338086974e38570a1f65bea8c202eb77a7"
-"checksum elastic-array 0.6.0 (git+https://github.com/ethcore/elastic-array)" = "<none>"
+"checksum elastic-array 0.6.0 (git+https://github.com/paritytech/elastic-array)" = "<none>"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum error-chain 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
-"checksum eth-secp256k1 0.5.6 (git+https://github.com/ethcore/rust-secp256k1)" = "<none>"
-"checksum ethcore-bigint 0.1.2 (git+https://github.com/ethcore/parity)" = "<none>"
-"checksum ethkey 0.2.0 (git+https://github.com/ethcore/parity)" = "<none>"
+"checksum eth-secp256k1 0.5.6 (git+https://github.com/paritytech/rust-secp256k1)" = "<none>"
+"checksum ethcore-bigint 0.1.2 (git+https://github.com/paritytech/parity)" = "<none>"
+"checksum ethkey 0.2.0 (git+https://github.com/paritytech/parity)" = "<none>"
 "checksum gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)" = "c07c758b972368e703a562686adb39125707cc1ef3399da8c019fc6c2498a75d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum heapsize 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5a376f7402b85be6e0ba504243ecbc0709c48019ecc6286d0540c2e359050c88"
@@ -405,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum png 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3cb773e9a557edb568ce9935cf783e3cdcabe06a9449d41b3e5506d88e582c82"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
-"checksum rlp 0.1.0 (git+https://github.com/ethcore/parity)" = "<none>"
+"checksum rlp 0.1.0 (git+https://github.com/paritytech/parity)" = "<none>"
 "checksum rust-crypto 0.2.36 (git+https://github.com/debris/rust-crypto)" = "<none>"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"

--- a/rust/signer/Cargo.toml
+++ b/rust/signer/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["debris <marek.kotewicz@gmail.com>"]
 [dependencies]
 libc = "0.2"
 rustc-serialize = "0.3"
-ethkey = { git = "https://github.com/ethcore/parity" }
-rlp = { git = "https://github.com/ethcore/parity" }
+ethkey = { git = "https://github.com/paritytech/parity" }
+rlp = { git = "https://github.com/paritytech/parity" }
 tiny-keccak = "1.1"
 blockies = "0.1"
 

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -3,9 +3,9 @@
 set -e
 
 # android
-multirust add-target stable aarch64-linux-android
-multirust add-target stable armv7-linux-androideabi
-multirust add-target stable i686-linux-android
+rustup target add aarch64-linux-android
+rustup target add armv7-linux-androideabi
+rustup target add i686-linux-android
 
 ./create-ndk-standalone.sh
 


### PR DESCRIPTION
@debris 

Could you check whether this broke something, because I had to push it with ```--no-verify``` but I think it is due to Linux and not being able to run iOS and watchman without problems.